### PR TITLE
:herb: Add additional properties decoding test

### DIFF
--- a/src/Pinecone.Test/Integration/Serialization/AdditionalProperties.cs
+++ b/src/Pinecone.Test/Integration/Serialization/AdditionalProperties.cs
@@ -6,7 +6,7 @@ using Pinecone;
 
 #nullable enable
 
-namespace Pinecone.Test;
+namespace Pinecone.Test.Integration.Serialization;
 
 [TestFixture]
 public class AdditionalPropertiesTest


### PR DESCRIPTION
This adds a test that confirms the SDK can handle unrecognized properties returned from the server. 

This is particularly relevant whenever the server is updated, but the user is on an old version of the client. In other words, this tests _forward compatibility_.