### PR TITLE
feat: Add `IsTlsEnabled` client option

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Control Plane endpoints are accessed via standard HTTP requests. You can configu
 - **Timeout**: The time limit for each request before it times out. Default is `30 seconds`.
 - **BaseUrl**: The base URL for all requests.
 - **HttpClient**: The HTTP client to be used for all requests.
+- **IsTlsEnabled**: The client will use HTTPS if set to `true`, HTTP if set to false. Default is `true`.
 
 Example usage:
 
@@ -657,8 +658,9 @@ var pinecone = new PineconeClient("PINECONE_API_KEY", new ClientOptions
 {
     MaxRetries = 3,
     Timeout = TimeSpan.FromSeconds(60),
-    HttpClient = ... // Override the Http Client
-    BaseUrl = ... // Override the Base URL
+    HttpClient = ..., // Override the Http Client
+    BaseUrl = ..., // Override the Base URL
+    IsTlsEnabled = true
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ Control Plane endpoints are accessed via standard HTTP requests. You can configu
 - **Timeout**: The time limit for each request before it times out. Default is `30 seconds`.
 - **BaseUrl**: The base URL for all requests.
 - **HttpClient**: The HTTP client to be used for all requests.
-- **IsTlsEnabled**: The client will use HTTPS if set to `true`, HTTP if set to false. Default is `true`.
+- **IsTlsEnabled**: The client will default to using HTTPS if `true`, and to HTTP if `false`. Default is `true`.
 
 Example usage:
 

--- a/src/Pinecone.Test/Integration/Control/Setup.cs
+++ b/src/Pinecone.Test/Integration/Control/Setup.cs
@@ -19,7 +19,15 @@ namespace Pinecone.Test.Integration.Control
             Console.WriteLine("Initializing control plane integration tests...");
             Client = new PineconeClient(
                 apiKey: Helpers.GetEnvironmentVar("PINECONE_API_KEY"),
-                new ClientOptions { SourceTag = "test-tag" }
+                new ClientOptions
+                {
+                    SourceTag = "test-tag", 
+                    BaseUrl = Helpers.GetEnvironmentVar("PINECONE_BASE_URL", BasePineconeEnvironment.Default),
+                    HttpClient = new HttpClient(new HttpClientHandler()
+                    {
+                        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                    })
+                }
             );
             PineconeEnvironment = "us-west1-gcp";
             Dimension = 2;

--- a/src/Pinecone.Test/Integration/Control/Setup.cs
+++ b/src/Pinecone.Test/Integration/Control/Setup.cs
@@ -22,11 +22,7 @@ namespace Pinecone.Test.Integration.Control
                 new ClientOptions
                 {
                     SourceTag = "test-tag", 
-                    BaseUrl = Helpers.GetEnvironmentVar("PINECONE_BASE_URL", BasePineconeEnvironment.Default),
-                    HttpClient = new HttpClient(new HttpClientHandler()
-                    {
-                        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                    })
+                    BaseUrl = Helpers.GetEnvironmentVar("PINECONE_BASE_URL", BasePineconeEnvironment.Default)
                 }
             );
             PineconeEnvironment = "us-west1-gcp";

--- a/src/Pinecone.Test/Integration/Data/Setup.cs
+++ b/src/Pinecone.Test/Integration/Data/Setup.cs
@@ -20,7 +20,11 @@ public class Setup
         Console.WriteLine("Initializing data plane integration tests...");
         Client = new PineconeClient(
             apiKey: Helpers.GetEnvironmentVar("PINECONE_API_KEY"),
-            new ClientOptions { SourceTag = "test-tag" }
+            new ClientOptions
+            {
+                SourceTag = "test-tag",
+                BaseUrl = Helpers.GetEnvironmentVar("PINECONE_BASE_URL", BasePineconeEnvironment.Default)
+            }
         );
         Metric = CreateIndexRequestMetric.Cosine;
         Spec = new ServerlessIndexSpec

--- a/src/Pinecone.Test/Integration/Data/TestSetupUpsertErrors.cs
+++ b/src/Pinecone.Test/Integration/Data/TestSetupUpsertErrors.cs
@@ -9,7 +9,10 @@ public class TestSetupUpsertErrors : BaseTest
     [Test]
     public void TestUpsertFailsWhenApiKeyInvalid()
     {
-        var pinecone = new PineconeClient(Helpers.FakeApiKey());
+        var pinecone = new PineconeClient(Helpers.FakeApiKey(), new ClientOptions
+        {
+            BaseUrl = Helpers.GetEnvironmentVar("PINECONE_BASE_URL", BasePineconeEnvironment.Default)
+        });
         var e = Assert.ThrowsAsync<PineconeApiException>(async () =>
         {
             var index = pinecone.Index(null, IndexHost);

--- a/src/Pinecone/Core/Public/IsTlsEnabledOption.cs
+++ b/src/Pinecone/Core/Public/IsTlsEnabledOption.cs
@@ -1,0 +1,10 @@
+namespace Pinecone;
+
+public partial class ClientOptions
+{
+    /// <summary>
+    /// When TLS is enabled, the client will use the HTTPS protocol. When disabled, the client will use the HTTP protocol.
+    /// Defaults to true.
+    /// </summary>
+    public bool IsTlsEnabled { get; init; } = true;
+}

--- a/src/Pinecone/Core/Public/IsTlsEnabledOption.cs
+++ b/src/Pinecone/Core/Public/IsTlsEnabledOption.cs
@@ -3,7 +3,7 @@ namespace Pinecone;
 public partial class ClientOptions
 {
     /// <summary>
-    /// When TLS is enabled, the client will use the HTTPS protocol. When disabled, the client will use the HTTP protocol.
+    /// When TLS is enabled, the client will default to using HTTPS, and when disabled, it will default to using HTTP.
     /// Defaults to true.
     /// </summary>
     public bool IsTlsEnabled { get; init; } = true;

--- a/src/Pinecone/Core/Public/Version.cs
+++ b/src/Pinecone/Core/Public/Version.cs
@@ -2,5 +2,5 @@ namespace Pinecone;
 
 internal class Version
 {
-    public const string Current = "2.0.1";
+    public const string Current = "2.1.0";
 }

--- a/src/Pinecone/Core/Public/Version.cs
+++ b/src/Pinecone/Core/Public/Version.cs
@@ -2,5 +2,5 @@ namespace Pinecone;
 
 internal class Version
 {
-    public const string Current = "2.0.0";
+    public const string Current = "2.0.1";
 }

--- a/src/Pinecone/Core/RawGrpcClient.cs
+++ b/src/Pinecone/Core/RawGrpcClient.cs
@@ -1,4 +1,3 @@
-using System;
 using Grpc.Core;
 using Grpc.Net.Client;
 
@@ -21,10 +20,7 @@ internal class RawGrpcClient
         _clientOptions = clientOptions;
 
         var grpcOptions = PrepareGrpcChannelOptions();
-        Channel =
-            grpcOptions != null
-                ? GrpcChannel.ForAddress(_clientOptions.BaseUrl, grpcOptions)
-                : GrpcChannel.ForAddress(_clientOptions.BaseUrl);
+        Channel = GrpcChannel.ForAddress(_clientOptions.BaseUrl, grpcOptions);
     }
 
     /// <summary>
@@ -65,13 +61,9 @@ internal class RawGrpcClient
         }
     }
 
-    private GrpcChannelOptions? PrepareGrpcChannelOptions()
+    private GrpcChannelOptions PrepareGrpcChannelOptions()
     {
-        var grpcChannelOptions = _clientOptions.GrpcOptions;
-        if (grpcChannelOptions == null)
-        {
-            return null;
-        }
+        var grpcChannelOptions = _clientOptions.GrpcOptions ?? new GrpcChannelOptions();
         grpcChannelOptions.HttpClient ??= _clientOptions.HttpClient;
         grpcChannelOptions.MaxRetryAttempts ??= _clientOptions.MaxRetries;
         return grpcChannelOptions;

--- a/src/Pinecone/Pinecone.csproj
+++ b/src/Pinecone/Pinecone.csproj
@@ -8,7 +8,7 @@
         <NuGetAudit>false</NuGetAudit>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>2.0.1</Version>
+        <Version>2.1.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <FileVersion>$(Version)</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Pinecone/Pinecone.csproj
+++ b/src/Pinecone/Pinecone.csproj
@@ -8,7 +8,7 @@
         <NuGetAudit>false</NuGetAudit>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <FileVersion>$(Version)</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Pinecone/PineconeClient.cs
+++ b/src/Pinecone/PineconeClient.cs
@@ -38,7 +38,7 @@ public class PineconeClient : BasePinecone
         var client = new RawClient(
             new ClientOptions
             {
-                BaseUrl = NormalizeHost(host),
+                BaseUrl = NormalizeHost(host, clientOptions.IsTlsEnabled),
                 HttpClient = clientOptions.HttpClient,
                 MaxRetries = clientOptions.MaxRetries,
                 Timeout = clientOptions.Timeout,
@@ -76,22 +76,18 @@ public class PineconeClient : BasePinecone
                 clientOptions.Headers[header.Key] = header.Value;
             }
         }
+
         if (clientOptions.SourceTag != null)
         {
             clientOptions.Headers["User-Agent"] =
                 $"lang=C#; version={Version.Current}; source_tag={clientOptions.SourceTag}";
         }
+
         return clientOptions;
     }
 
-    private string NormalizeHost(string host)
-    {
-        if (host.StartsWith("https://") || host.StartsWith("http://"))
-        {
-            return host;
-        }
-        return "https://" + host;
-    }
+    private static string NormalizeHost(string host, bool isTlsEnabled)
+        => $"{(isTlsEnabled ? "https" : "http")}://{host}";
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/src/Pinecone/PineconeClient.cs
+++ b/src/Pinecone/PineconeClient.cs
@@ -87,7 +87,14 @@ public class PineconeClient : BasePinecone
     }
 
     private static string NormalizeHost(string host, bool isTlsEnabled)
-        => $"{(isTlsEnabled ? "https" : "http")}://{host}";
+    {
+        if(host.StartsWith("http://") || host.StartsWith("https://"))
+        {
+            return host;
+        }
+        
+        return $"{(isTlsEnabled ? "https" : "http")}://{host}";
+    }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {


### PR DESCRIPTION
If `IsTlsEnabled` is `true` (default), the generated index clients will use `https,` otherwise, `http`. 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Tested using C# script equivalent of the Java test provided by Rohan.
